### PR TITLE
Solve invalid value in variance calculation

### DIFF
--- a/sigmt/__version__.py
+++ b/sigmt/__version__.py
@@ -1,4 +1,4 @@
 """
 Returns version of the package
 """
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/sigmt/core/robust_estimation.py
+++ b/sigmt/core/robust_estimation.py
@@ -379,7 +379,7 @@ class RobustEstimation:
         else:
             db = 100
 
-        self.z1_var = np.sqrt(np.real(da))
-        self.z2_var = np.sqrt(np.real(db))
+        self.z1_var = np.sqrt(abs(np.real(da)))
+        self.z2_var = np.sqrt(abs(np.real(db)))
         #
         self.predicted_coherency = np.sqrt(coh)


### PR DESCRIPTION
This update addresses an issue where the variance calculation function was encountering a negative value under the square root, resulting in NaN values. These NaNs were subsequently printed in the EDI outputs, causing inconsistencies