### PR TITLE
Fix: EDI merger sorting issue

### DIFF
--- a/sigmt/__version__.py
+++ b/sigmt/__version__.py
@@ -1,4 +1,4 @@
 """
 Returns version of the package
 """
-__version__ = "2.0.5"
+__version__ = "2.0.6"

--- a/sigmt/gui/edi_merger.py
+++ b/sigmt/gui/edi_merger.py
@@ -230,7 +230,7 @@ class EDIMerger(QWidget):
         Save merged EDI
         """
         data_frame = self.data.to_dataframe().reset_index()
-        data_frame = data_frame.sort_values(by=["frequency"], ascending=[False])
+        data_frame = data_frame.sort_values(by=["frequency"], ascending=False).reset_index(drop=True)
 
         file_formats = "EDI Files (*.edi);;All Files (*)"
         save_path, _ = QFileDialog.getSaveFileName(None, "Save File", "", file_formats)


### PR DESCRIPTION
**Issue:**
A user reported that the output EDI file generated by the EDI Merger had a sorting issue—specifically, the frequency values were not sorted in any defined order.

**Impact:**
The sorting issue did not affect the alignment or integrity of the data values in the file, but it caused confusion and reduced readability.

**Fix:**
This update introduces proper sorting of the frequency values in the EDI output to ensure consistency and improve clarity for users reviewing the file.